### PR TITLE
fix: typo in `module` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://www.github.com/sw-yx/react-netlify-identity",
   "main": "dist/index.js",
   "umd:main": "dist/react-netlify-identity.umd.production.js",
-  "module": "dist/react-netlify-identity.es.production.js",
+  "module": "dist/react-netlify-identity.esm.production.js",
   "typings": "dist/index.d.ts",
   "jsnext:main": "dist/index.es.js",
   "engines": {


### PR DESCRIPTION
closes #48

The build process generates a `.esm` file, but the `package.json` currently lists `.es`. That's a typo we need to fix :)
<img width="1153" alt="Screenshot 2022-06-13 at 10 49 08" src="https://user-images.githubusercontent.com/14912729/173316109-b0f83e8e-3e92-481d-8925-a2371f18f5f3.png">

